### PR TITLE
osc loadbalancername limitation: max length 32

### DIFF
--- a/helm-charts/capi-cluster/charts/outscale/templates/OscCluster.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/OscCluster.yaml
@@ -49,7 +49,7 @@ spec:
         backendprotocol: TCP
         loadbalancerport: 6443
         loadbalancerprotocol: TCP
-      loadbalancername: {{ .Values.loadbalancername | default "{{ .Values.global.clusterName }}-k8s" }}
+      loadbalancername: {{ template "outscale.defaultLoadbalancerName" $ }}
       loadbalancertype: internet-facing
     natService:
       clusterName: {{ .Values.global.clusterName }}

--- a/helm-charts/capi-cluster/charts/outscale/templates/OscMachineTemplate-control-plane.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/OscMachineTemplate-control-plane.yaml
@@ -14,7 +14,7 @@ spec:
         vm:
           clusterName: {{ .Values.global.clusterName }}
           keypairName: {{ .Values.sshkeyname }}
-          loadBalancerName: {{ .Values.loadbalancername | default "{{ .Values.global.clusterName }}-k8s" }}
+          loadBalancerName: {{ template "outscale.defaultLoadbalancerName" $ }}
           role: controlplane
           vmType: {{ .Values.controlplane.vmType }}
           subregionName: {{ .Values.controlplane.subregionName  }}

--- a/helm-charts/capi-cluster/charts/outscale/templates/_helpers.tpl
+++ b/helm-charts/capi-cluster/charts/outscale/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Define Loadbalancer name : outscale limitation is max length 32
+ default: if no loadbalancername is specified, generate 32 max length loadbalancername from trunc(28, sha256(cluster name))"-k8s"
+*/}}
+
+{{- define "outscale.defaultLoadbalancerName" -}}
+{{- $loadbalancername := printf "%s-%s" (lower "{{ .Values.global.clusterName }}" | sha256sum | trunc 28 ) "k8s" }}
+{{- if and (hasKey .Values "loadbalancername") (not (empty .Values.loadbalancername)) }}
+{{- $loadbalancername = .Values.loadbalancername }}
+{{- end }}
+{{- $loadbalancername }}
+{{- end }}
+


### PR DESCRIPTION
Outscale loadbalancername limitation: max length 32