### PR TITLE
WIP: feat(security): apply hardening configuration to clusters hosted on O…

### DIFF
--- a/helm-charts/capi-cluster/charts/outscale/templates/KubeadmConfigTemplate.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/KubeadmConfigTemplate.yaml
@@ -10,10 +10,33 @@ spec:
       joinConfiguration:
         nodeRegistration:
           imagePullPolicy: IfNotPresent
-          name: {{`'{{ ds.meta_data.local_hostname }}'`}}
+          name: "{{`'{{ ds.meta_data.local_hostname }}'`}}"
           kubeletExtraArgs:
-            cloud-provider: external
-            provider-id: {{`'aws:///{{ ds.meta_data.placement.availability_zone }}/{{ ds.meta_data.instance_id }}'`}}
+            cloud-provider: "external"
+            anonymous-auth: "false"
+            container-log-max-files: "10"
+            container-log-max-size: 50Mi
+            event-burst: "100"
+            event-qps: "100"
+            eviction-hard: imagefs.available<10%,memory.available<100Mi,nodefs.available<5%,nodefs.inodesFree<5%
+            eviction-max-pod-grace-period: "180"
+            eviction-soft: imagefs.available<15%,memory.available<300Mi,nodefs.available<10%,nodefs.inodesFree<10%
+            eviction-soft-grace-period: imagefs.available=5m0s,memory.available=5m0s,nodefs.available=30m0s,nodefs.inodesFree=30m0s
+            fail-swap-on: "true"
+            feature-gates: "EventedPLEG=true,HPAScaleToZero=true,KubeletCgroupDriverFromCRI=true,KubeletPodResourcesGet=true,QOSReserved=true,RecoverVolumeExpansionFailure=true,SELinuxMountReadWriteOncePod=true"
+            image-gc-low-threshold: "50"
+            kernel-memcg-notification: "true"
+            kube-reserved: "cpu=300m,memory=500Mi,ephemeral-storage=1Gi,pid='1000'"
+            system-reserved: "cpu=200m,memory=200Mi,ephemeral-storage=1Gi,pid='1000'"
+            max-pods: "110"
+            registry-burst: "10"
+            registry-qps: "5"
+            rotate-certificates: "true"
+            serialize-image-pulls: "false"
+            tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+            tls-min-version: "VersionTLS12"
+            v: "5"
+            provider-id: {{`"aws:///{{ ds.meta_data.placement.availability_zone }}/{{ ds.meta_data.instance_id }}"`}}
             {{- with $pool.nodeLabels }}
             node-labels: "{{ range $i, $k := (keys . | sortAlpha) }}{{ if ne $i 0 }},{{ end }}{{ $k }}={{ index $pool.nodeLabels $k }}{{ end }}"
             {{- end }}
@@ -26,36 +49,92 @@ spec:
         - for script in $(find /etc/post-kubeadm-commands/ -name '*.sh' -type f | sort);
           do echo "Running script $script"; "$script"; done
       files:
-      - content: |
-          #!/bin/bash
-          set +e
-          # Define the retry function
-          wait_and_retry() {
-            local retries="$1"
-            local wait="$2"
-            local command="$3"
+        - path: /etc/pre-kubeadm-commands/00-wait_endpoint.sh
+          owner: root:root
+          permissions: "0755"
+          content: |
+            #!/bin/bash
+            set +e
+            # Define the retry function
+            wait_and_retry() {
+              local retries="$1"
+              local wait="$2"
+              local command="$3"
 
-            $command
-            local exit_code=$?
+              $command
+              local exit_code=$?
 
-            if [[ $exit_code -ne 0 && $retries -gt 0 ]]; then
-              echo "# Wait $wait before retrying $retries : $command"
-              sleep $wait
-              wait_and_retry $(($retries - 1)) $wait "$command"
-            else
-              return $exit_code
-            fi
-          }
-          # wait endpoint is up
-          endpoint=""
-          [[ -f /run/kubeadm/kubeadm.yaml ]] && endpoint=$(grep "controlPlaneEndpoint" /run/kubeadm/kubeadm.yaml|awk ' {print $2 }' |sed -e 's/ //g;s/:.*//g')
-          [[ -f  /run/kubeadm/kubeadm-join-config.yaml ]] && endpoint=$(grep "apiServerEndpoint" /run/kubeadm/kubeadm-join-config.yaml |awk ' {print $2 }' |sed -e 's/ //g;s/:.*//g')
-          [[ -n "$endpoint" ]] && wait_and_retry 360 10 "host $endpoint"
-          # wait external access is up
-          external_url="github.com"
-          [[ -n "$external_url" ]] && wait_and_retry 360 10 "host $external_url"
-        owner: root:root
-        path: /etc/pre-kubeadm-commands/00-wait_endpoint.sh
-        permissions: "0755"
+              if [[ $exit_code -ne 0 && $retries -gt 0 ]]; then
+                echo "# Wait $wait before retrying $retries : $command"
+                sleep $wait
+                wait_and_retry $(($retries - 1)) $wait "$command"
+              else
+                return $exit_code
+              fi
+            }
+            # wait endpoint is up
+            endpoint=""
+            [[ -f /run/kubeadm/kubeadm.yaml ]] && endpoint=$(grep "controlPlaneEndpoint" /run/kubeadm/kubeadm.yaml|awk ' {print $2 }' |sed -e 's/ //g;s/:.*//g')
+            [[ -f  /run/kubeadm/kubeadm-join-config.yaml ]] && endpoint=$(grep "apiServerEndpoint" /run/kubeadm/kubeadm-join-config.yaml |awk ' {print $2 }' |sed -e 's/ //g;s/:.*//g')
+            [[ -n "$endpoint" ]] && wait_and_retry 360 10 "host $endpoint"
+            # wait external access is up
+            external_url="github.com"
+            [[ -n "$external_url" ]] && wait_and_retry 360 10 "host $external_url"
+        - path: /etc/pre-kubeadm-commands/10-containerd-restart.sh
+          owner: root:root
+          permissions: "0700"
+          content: |
+            #!/bin/bash
+            #
+            # pre-kubadm-scripts
+            #
+            set -e
+            # apply containerd config before kubeadm
+            echo "## restart containerd"
+            systemctl daemon-reload
+            systemctl restart containerd
+        - path: /etc/apt/apt.conf.d/99proxy
+          owner: "root:root"
+          permissions: "0644"
+          content: |
+            Acquire {
+              {{- if .Values.global.http_proxy }}
+              http::Proxy {{ .Values.global.http_proxy | quote }};
+              {{- end }}
+              {{- if .Values.global.https_proxy }}
+              https::Proxy {{ .Values.global.https_proxy | quote }};
+              {{- end }}
+            }
+        - path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+          owner: root:root
+          permissions: "0755"
+          content: |
+            #!/bin/bash
+            set +e
+            # Define the retry function
+            wait_and_retry() {
+              local retries="$1"
+              local wait="$2"
+              local command="$3"
+
+              $command
+              local exit_code=$?
+
+              if [[ $exit_code -ne 0 && $retries -gt 0 ]]; then
+                echo "# Wait $wait before retrying $retries : $command"
+                sleep $wait
+                wait_and_retry $(($retries - 1)) $wait "$command"
+              else
+                return $exit_code
+              fi
+            }
+            # wait endpoint is up
+            endpoint=""
+            [[ -f /run/kubeadm/kubeadm.yaml ]] && endpoint=$(grep "controlPlaneEndpoint" /run/kubeadm/kubeadm.yaml|awk ' {print $2 }' |sed -e 's/ //g;s/:.*//g')
+            [[ -f  /run/kubeadm/kubeadm-join-config.yaml ]] && endpoint=$(grep "apiServerEndpoint" /run/kubeadm/kubeadm-join-config.yaml |awk ' {print $2 }' |sed -e 's/ //g;s/:.*//g')
+            [[ -n "$endpoint" ]] && wait_and_retry 360 10 "host $endpoint"
+            # wait external access is up
+            external_url="github.com"
+            [[ -n "$external_url" ]] && wait_and_retry 360 10 "host $external_url"
 ---
 {{- end }}

--- a/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
@@ -10,40 +10,127 @@ spec:
       apiServer:
         timeoutForControlPlane: 20m0s
         extraArgs:
-          cloud-provider: external
+          allow-privileged: "true"
+          audit-log-maxsize: "100"
+          audit-log-maxbackup: "10"
+          audit-log-path: "/var/log/kubernetes/audit.log"
+          audit-policy-file: "/etc/kubernetes/audit-policy.yaml"
+          authorization-mode: "RBAC,Node"
+          cloud-provider: "external"
+          enable-bootstrap-token-auth: "true"
+          enable-admission-plugins: "NodeRestriction,AlwaysPullImages"
+          # encryption-provider-config: "xxxx"
+          event-ttl: "4h"
+          feature-gates: "EventedPLEG=true,HPAScaleToZero=true,QOSReserved=true,RecoverVolumeExpansionFailure=true,SELinuxMountReadWriteOncePod=true"
+          requestheader-allowed-names: "front-proxy-client"
+          requestheader-client-ca-file: "/etc/kubernetes/pki/front-proxy-ca.crt"
+          requestheader-extra-headers-prefix: "X-Remote-Extra-"
+          requestheader-group-headers: "X-Remote-Group"
+          requestheader-username-headers: "X-Remote-User"
+          tls-min-version: "VersionTLS12"
+          tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+          v: "5"
+        extraVolumes:
+          - name: "audit-policy"
+            pathType: "File"
+            hostPath: "/etc/kubernetes/audit-policy.yaml"
+            mountPath: "/etc/kubernetes/audit-policy.yaml"
+            readOnly: true
+          - name: "audit-logs"
+            hostPath: "/var/log/kubernetes"
+            mountPath: "/var/log/kubernetes"
+          - name: "admission-pss"
+            pathType: "File"
+            hostPath: "/etc/kubernetes/kube-apiserver-admission-pss.yaml"
+            mountPath: "/etc/kubernetes/kube-apiserver-admission-pss.yaml"
+            readOnly: true
       controllerManager:
         extraArgs:
-          cloud-provider: external
-#      etcd:
-#        local:
-#          extraArgs:
-#            listen-client-urls: {{`'https://{{ ds.meta_data.local_ipv4 }}:2379'`}}
-#            election-timeout: "5000" ## debug
-#            heartbeat-interval: "500"
-#            snapshot-count: "5000"
-### use external etcd volume dir
-#           quota-backend-bytes: "8589934592"
-#          dataDir: /var/lib/etcddisk/etcd ## We Change the etcd data dir when moving to dedicated volume (because of "dir is not empty")
+          allocate-node-cidrs: "false"
+          cloud-provider: "external"
+          cluster-name: {{ .Values.global.clusterName | default "clusterNameIsNotDefined" }}
+          feature-gates: "EventedPLEG=true,HPAScaleToZero=true,QOSReserved=true,RecoverVolumeExpansionFailure=true,SELinuxMountReadWriteOncePod=true"
+          tls-min-version: "VersionTLS12"
+          tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+          v: "5"
+      etcd:
+        local:
+          dataDir: "/var/lib/etcd"
+          extraArgs:
+            auto-compaction-retention: "1"
+            quota-backend-bytes: "8589934592"
+            experimental-initial-corrupt-check: "true"
+            experimental-warning-apply-duration: "200ms"
+            experimental-bootstrap-defrag-threshold-megabytes: "512"
+            tls-min-version: "TLS1.2"
+            v2-deprecation: "gone"
+      scheduler:
+        extraArgs:
+          feature-gates: "EventedPLEG=true,HPAScaleToZero=true,QOSReserved=true,RecoverVolumeExpansionFailure=true,SELinuxMountReadWriteOncePod=true"
+          tls-min-version: "VersionTLS12"
+          tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+          v: "5"
     initConfiguration:
-#      localAPIEndpoint:
-#        advertiseAddress: {{`'{{ ds.meta_data.local_ipv4 }}'`}}
-#        bindPort: 6443
       {{ if and .Values.global.addons.cni.enabled ( eq .Values.global.addons.cni.type "cilium" ) -}}
       # cilium replace kube-proxy
       skipPhases:
         - addon/kube-proxy
       {{ end -}}
       nodeRegistration:
-        name: {{`'{{ ds.meta_data.local_hostname }}'`}}
+        name: "{{`'{{ ds.meta_data.local_hostname }}'`}}"
         kubeletExtraArgs:
-          cloud-provider: external
-          provider-id: {{`'aws:///{{ ds.meta_data.placement.availability_zone }}/{{ ds.meta_data.instance_id }}'`}}
+          cloud-provider: "external"
+          anonymous-auth: "false"
+          container-log-max-files: "10"
+          container-log-max-size: 50Mi
+          event-burst: "100"
+          event-qps: "100"
+          eviction-hard: imagefs.available<10%,memory.available<100Mi,nodefs.available<5%,nodefs.inodesFree<5%
+          eviction-max-pod-grace-period: "180"
+          eviction-soft: imagefs.available<15%,memory.available<300Mi,nodefs.available<10%,nodefs.inodesFree<10%
+          eviction-soft-grace-period: imagefs.available=5m0s,memory.available=5m0s,nodefs.available=30m0s,nodefs.inodesFree=30m0s
+          fail-swap-on: "true"
+          feature-gates: "EventedPLEG=true,HPAScaleToZero=true,KubeletCgroupDriverFromCRI=true,KubeletPodResourcesGet=true,QOSReserved=true,RecoverVolumeExpansionFailure=true,SELinuxMountReadWriteOncePod=true"
+          image-gc-low-threshold: "50"
+          kernel-memcg-notification: "true"
+          kube-reserved: "cpu=300m,memory=500Mi,ephemeral-storage=1Gi,pid='1000'"
+          system-reserved: "cpu=200m,memory=200Mi,ephemeral-storage=1Gi,pid='1000'"
+          max-pods: "110"
+          registry-burst: "10"
+          registry-qps: "5"
+          rotate-certificates: "true"
+          serialize-image-pulls: "false"
+          tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+          tls-min-version: "VersionTLS12"
+          v: "5"
     joinConfiguration:
       nodeRegistration:
-        name: {{`'{{ ds.meta_data.local_hostname }}'`}}
+        name: "{{`'{{ ds.meta_data.local_hostname }}'`}}"
         kubeletExtraArgs:
-          cloud-provider: external
-          provider-id: {{`'aws:///{{ ds.meta_data.placement.availability_zone }}/{{ ds.meta_data.instance_id }}'`}}
+          cloud-provider: "external"
+          anonymous-auth: "false"
+          container-log-max-files: "10"
+          container-log-max-size: 50Mi
+          event-burst: "100"
+          event-qps: "100"
+          eviction-hard: imagefs.available<10%,memory.available<100Mi,nodefs.available<5%,nodefs.inodesFree<5%
+          eviction-max-pod-grace-period: "180"
+          eviction-soft: imagefs.available<15%,memory.available<300Mi,nodefs.available<10%,nodefs.inodesFree<10%
+          eviction-soft-grace-period: imagefs.available=5m0s,memory.available=5m0s,nodefs.available=30m0s,nodefs.inodesFree=30m0s
+          fail-swap-on: "true"
+          feature-gates: "EventedPLEG=true,HPAScaleToZero=true,KubeletCgroupDriverFromCRI=true,KubeletPodResourcesGet=true,QOSReserved=true,RecoverVolumeExpansionFailure=true,SELinuxMountReadWriteOncePod=true"
+          image-gc-low-threshold: "50"
+          kernel-memcg-notification: "true"
+          kube-reserved: "cpu=300m,memory=500Mi,ephemeral-storage=1Gi,pid='1000'"
+          system-reserved: "cpu=200m,memory=200Mi,ephemeral-storage=1Gi,pid='1000'"
+          max-pods: "110"
+          registry-burst: "10"
+          registry-qps: "5"
+          rotate-certificates: "true"
+          serialize-image-pulls: "false"
+          tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+          tls-min-version: "VersionTLS12"
+          v: "5"
 # cloud-init
 ##  Add external volume for etcd
 #    diskSetup:
@@ -71,58 +158,10 @@ spec:
       - for script in $(find /etc/post-kubeadm-commands/ -name '*.sh' -type f | sort);
         do echo "Running script $script"; "$script"; done
     files:
-      - content: |
-          #!/bin/bash
-          #
-          # pre-kubadm-scripts
-          #
-          set -e
-          # apply containerd config before kubeadm
-          echo "## restart containerd"
-          systemctl daemon-reload
-          systemctl restart containerd
+      - path: /etc/pre-kubeadm-commands/00-wait_endpoint.sh
         owner: root:root
-        path: /etc/pre-kubeadm-commands/10-containerd-restart.sh.disable
-        permissions: "0700"
-      - content: |
-          #!/bin/bash
-          grep '^      limits:' /etc/kubernetes/manifests/kube-apiserver.yaml >/dev/null 2>&1 && exit 0
-          MEM=$(free -m | grep '^Mem:' | awk '{print $2;}')
-          CPU=$(grep '^processor' /proc/cpuinfo | wc -l)
-          sed -i "/^ *requests:/i\      limits:\n        memory: $((10+3*$MEM/4))M\n        cpu: $((750*$CPU))m" /etc/kubernetes/manifests/kube-apiserver.yaml
-          sed -i "/^ *requests:/a\        memory: 512M" /etc/kubernetes/manifests/kube-apiserver.yaml
-          sync
-          systemctl restart kubelet
-        owner: root:root
-        path: /etc/post-kubeadm-commands/10-tweak-kubeapi-memlimit.sh.disable
-        permissions: "0700"
-      - path: /etc/apt/apt.conf.d/99proxy
-        owner: "root:root"
-        permissions: "0644"
+        permissions: "0755"
         content: |
-          Acquire {
-            {{- if .Values.global.http_proxy }}
-            http::Proxy {{ .Values.global.http_proxy | quote }};
-            {{- end }}
-            {{- if .Values.global.https_proxy }}
-            https::Proxy {{ .Values.global.https_proxy | quote }};
-            {{- end }}
-            }
-      - path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-        owner: "root:root"
-        permissions: "0644"
-        content: |
-          [Service]
-          {{- if .Values.global.http_proxy }}
-          Environment="HTTP_PROXY={{ .Values.global.http_proxy }}"
-          {{- end }}
-          {{- if .Values.global.https_proxy }}
-          Environment="HTTPS_PROXY={{ .Values.global.https_proxy }}"
-          {{- end }}
-          {{- if .Values.global.no_proxy }}
-          Environment="NO_PROXY=.svc,.svc.cluster,.svc.cluster.local,127.0.0.0/8,192.168.0.0/16,{{ .Values.global.pods.cidrBlocks }},{{ .Values.global.services.cidrBlocks }}"
-          {{- end }}
-      - content: |
           #!/bin/bash
           set +e
           # Define the retry function
@@ -150,9 +189,242 @@ spec:
           # wait external access is up
           external_url="github.com"
           [[ -n "$external_url" ]] && wait_and_retry 360 10 "host $external_url"
+      - path: /etc/pre-kubeadm-commands/10-containerd-restart.sh
         owner: root:root
-        path: /etc/pre-kubeadm-commands/00-wait_endpoint.sh
-        permissions: "0755"
+        permissions: "0700"
+        content: |
+          #!/bin/bash
+          #
+          # pre-kubadm-scripts
+          #
+          set -e
+          # apply containerd config before kubeadm
+          echo "## restart containerd"
+          systemctl daemon-reload
+          systemctl restart containerd
+      - path: /etc/post-kubeadm-commands/10-tweak-kubeapi-memlimit.sh.disable
+        owner: root:root
+        permissions: "0700"
+        content: |
+          #!/bin/bash
+          grep '^      limits:' /etc/kubernetes/manifests/kube-apiserver.yaml >/dev/null 2>&1 && exit 0
+          MEM=$(free -m | grep '^Mem:' | awk '{print $2;}')
+          CPU=$(grep '^processor' /proc/cpuinfo | wc -l)
+          sed -i "/^ *requests:/i\      limits:\n        memory: $((10+3*$MEM/4))M\n        cpu: $((750*$CPU))m" /etc/kubernetes/manifests/kube-apiserver.yaml
+          sed -i "/^ *requests:/a\        memory: 512M" /etc/kubernetes/manifests/kube-apiserver.yaml
+          sync
+          systemctl restart kubelet
+      - path: /etc/apt/apt.conf.d/99proxy
+        owner: "root:root"
+        permissions: "0644"
+        content: |
+          Acquire {
+            {{- if .Values.global.http_proxy }}
+            http::Proxy {{ .Values.global.http_proxy | quote }};
+            {{- end }}
+            {{- if .Values.global.https_proxy }}
+            https::Proxy {{ .Values.global.https_proxy | quote }};
+            {{- end }}
+            }
+      - path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+        owner: "root:root"
+        permissions: "0644"
+        content: |
+          [Service]
+          {{- if .Values.global.http_proxy }}
+          Environment="HTTP_PROXY={{ .Values.global.http_proxy }}"
+          {{- end }}
+          {{- if .Values.global.https_proxy }}
+          Environment="HTTPS_PROXY={{ .Values.global.https_proxy }}"
+          {{- end }}
+          {{- if .Values.global.no_proxy }}
+          Environment="NO_PROXY=.svc,.svc.cluster,.svc.cluster.local,127.0.0.0/8,192.168.0.0/16,{{ .Values.global.pods.cidrBlocks }},{{ .Values.global.services.cidrBlocks }}"
+          {{- end }}
+      - path: /etc/kubernetes/audit-policy.yaml
+        owner: "root:root"
+        permissions: "0600"
+        content: |
+          apiVersion: audit.k8s.io/v1
+          kind: Policy
+          rules:
+          - level: None
+            users:
+            - system:serviceaccount:kube-system:kube-proxy
+            verbs:
+            - watch
+            resources:
+            - group: ""
+              resources:
+              - endpoints
+              - services
+              - services/status
+          - level: None
+            userGroups:
+            - system:nodes
+            verbs:
+            - get
+            resources:
+            - group: ""
+              resources:
+              - nodes
+              - nodes/status
+          - level: None
+            users:
+            - system:kube-controller-manager
+            - system:kube-scheduler
+            - system:serviceaccount:kube-system:endpoint-controller
+            verbs:
+            - get
+            - update
+            namespaces:
+            - kube-system
+            resources:
+            - group: ""
+              resources:
+              - endpoints
+          - level: None
+            users:
+            - system:apiserver
+            verbs:
+            - get
+            resources:
+            - group: ""
+              resources:
+              - namespaces
+              - namespaces/status
+              - namespaces/finalize
+          - level: None
+            users:
+            - system:kube-controller-manager
+            verbs:
+            - get
+            - list
+            resources:
+            - group: metrics.k8s.io
+          - level: None
+            nonResourceURLs:
+            - /healthz*
+            - /version
+            - /swagger*
+          - level: None
+            resources:
+            - group: ""
+              resources:
+              - events
+          - level: None
+            users:
+            - system:serviceaccount:kube-system:generic-garbage-collector
+            verbs:
+            - get
+            - list
+            - watch
+          - level: Request
+            userGroups:
+            - system:nodes
+            verbs:
+            - update
+            - patch
+            resources:
+            - group: ""
+              resources:
+              - nodes/status
+              - pods/status
+            omitStages:
+            - RequestReceived
+          - level: Request
+            users:
+            - system:serviceaccount:kube-system:namespace-controller
+            verbs:
+            - deletecollection
+            omitStages:
+            - RequestReceived
+          - level: Metadata
+            resources:
+            - group: ""
+              resources:
+              - secrets
+              - configmaps
+            - group: authentication.k8s.io
+              resources:
+              - tokenreviews
+            omitStages:
+            - RequestReceived
+          - level: Request
+            verbs:
+            - get
+            - list
+            - watch
+            resources:
+            - group: ""
+            - group: admissionregistration.k8s.io
+            - group: apiextensions.k8s.io
+            - group: apiregistration.k8s.io
+            - group: apps
+            - group: authentication.k8s.io
+            - group: authorization.k8s.io
+            - group: autoscaling
+            - group: batch
+            - group: certificates.k8s.io
+            - group: extensions
+            - group: metrics.k8s.io
+            - group: networking.k8s.io
+            - group: policy
+            - group: rbac.authorization.k8s.io
+            - group: settings.k8s.io
+            - group: storage.k8s.io
+            omitStages:
+            - RequestReceived
+          - level: RequestResponse
+            resources:
+            - group: ""
+            - group: admissionregistration.k8s.io
+            - group: apiextensions.k8s.io
+            - group: apiregistration.k8s.io
+            - group: apps
+            - group: authentication.k8s.io
+            - group: authorization.k8s.io
+            - group: autoscaling
+            - group: batch
+            - group: certificates.k8s.io
+            - group: extensions
+            - group: metrics.k8s.io
+            - group: networking.k8s.io
+            - group: policy
+            - group: rbac.authorization.k8s.io
+            - group: settings.k8s.io
+            - group: storage.k8s.io
+            omitStages:
+            - RequestReceived
+          - level: Metadata
+            omitStages:
+            - RequestReceived
+      - path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+        owner: root:root
+        permissions: "0444"
+        content: |
+          # Do not apply default pod security admission
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: AdmissionConfiguration
+          plugins:
+          - name: PodSecurity
+            configuration:
+              apiVersion: pod-security.admission.config.k8s.io/v1beta1
+              kind: PodSecurityConfiguration
+              defaults:
+                enforce: ""
+                enforce-version: "latest"
+                audit: ""
+                audit-version: "latest"
+                warn: ""
+                warn-version: "latest"
+              exemptions:
+                usernames: []
+                runtimeClasses: []
+                namespaces:
+                  - kube-system
+                  - ingress-nginx
+                  - monitoring
+                  - promtail
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
feat(security): apply hardening configuration to clusters hosted on Outscale and built using CAPI 'legacy' mode

- config of KubeadmConfigTemplate (`kubelet`)
- config of KubeadmControlPlane (`etcd`, `apiserver`, `controller-manager`, `scheduler`, `kubelet`)
- enable `audit-log`
- prepare the landing of `pss/psa` (currently not defined/enforced)

/!\/!\/!\ DO NOT MERGE YET: need to run a last test ;) /!\/!\/!\