### PR TITLE
fix(security): add extra namespaces in the exemption list of our PSS

### DIFF
--- a/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
@@ -414,6 +414,11 @@ spec:
                   - ingress-nginx
                   - monitoring
                   - promtail
+                  - argocd                                  # TODO: make this component compliant with our PSS policy
+                  - capi-operator-system                    # TODO: make this component compliant with our PSS policy
+                  - cluster-api-provider-outscale-system    # TODO: make this component compliant with our PSS policy
+                  - loki                                    # TODO: make this component compliant with our PSS policy
+                  - whoami                                  # TODO: make this component compliant with our PSS policy
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Add extra namespaces in the list of those that are not constrained by our PSS configuration.  
This is needed so that all our internal components start properly