### PR TITLE
fix(capi-clusterclasses): fix default values

### DIFF
--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -44,8 +44,10 @@ index-repo:
 
 SHELL := /bin/bash
 check-template:
-	[[ -n "${HELM_VALUE}" && -n "${CLUSTER_NAME}" ]] || exit 1
+	@[[ -n "${HELM_VALUE}" && -n "${CLUSTER_NAME}" ]] || exit 1
 template-capi-cluster: check-template
-	helm template -f ${HELM_VALUE} ${CLUSTER_NAME} capi-cluster
+	@helm template -f ${HELM_VALUE} ${CLUSTER_NAME} capi-cluster
 template-capi-cluster-addons: check-template
-	helm template -f ${HELM_VALUE} ${CLUSTER_NAME} capi-cluster-addons
+	@helm template -f ${HELM_VALUE} ${CLUSTER_NAME} capi-cluster-addons
+template-capi-clusterclasses: check-template
+	@helm template -f ${HELM_VALUE} ${CLUSTER_NAME} capi-clusterclasses

--- a/helm-charts/capi-cluster/charts/outscale-clusterclass/templates/Cluster.yaml
+++ b/helm-charts/capi-cluster/charts/outscale-clusterclass/templates/Cluster.yaml
@@ -76,8 +76,10 @@ spec:
         value: {{ .Values.clusterClass.variables.sshKeypairName }}
       - name: subregionName
         value: {{ .Values.clusterClass.variables.subregionName | quote }}
+      {{- if hasKey .Values.clusterClass.variables "coreDNSVersion" }}
       - name: coreDNSVersion
         value: {{ .Values.clusterClass.variables.coreDNSVersion | quote }}
+      {{- end }}
       - name: vmImageName
         value: {{ .Values.clusterClass.variables.vmImageName | quote }}
       - name: controlPlane

--- a/helm-charts/capi-cluster/charts/outscale-clusterclass/templates/Cluster.yaml
+++ b/helm-charts/capi-cluster/charts/outscale-clusterclass/templates/Cluster.yaml
@@ -74,6 +74,8 @@ spec:
         {{- end }}
       - name: sshKeypairName
         value: {{ .Values.clusterClass.variables.sshKeypairName }}
+      - name: subregionName
+        value: {{ .Values.clusterClass.variables.subregionName | quote }}
       - name: coreDNSVersion
         value: {{ .Values.clusterClass.variables.coreDNSVersion | quote }}
       - name: vmImageName

--- a/helm-charts/capi-cluster/charts/outscale-clusterclass/values.yaml
+++ b/helm-charts/capi-cluster/charts/outscale-clusterclass/values.yaml
@@ -49,7 +49,7 @@
 #     # Version of CoreDNS to use
 #     # this must be consistent with clusterClass.kubernetesVersion
 #     # for default version for each kubernets versions:
-#     # https://github.com/kubernetes/kubernetes/blob/v1.28.5/cmd/kubeadm/app/constants/constants.go#L344
+#     # https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md
 #     coreDNSVersion: "v1.10.1"
 
 #     # Name of a valid VM image to use to provision all the

--- a/helm-charts/capi-cluster/values.yaml
+++ b/helm-charts/capi-cluster/values.yaml
@@ -212,7 +212,7 @@ outscale-clusterclass: {}
 #     # Version of CoreDNS to use
 #     # this must be consistent with clusterClass.kubernetesVersion
 #     # for default version for each kubernets versions:
-#     # https://github.com/kubernetes/kubernetes/blob/v1.28.5/cmd/kubeadm/app/constants/constants.go#L344
+#     # https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md
 #     coreDNSVersion: "v1.10.1"
 
 #     # Name of a valid VM image to use to provision all the

--- a/helm-charts/capi-clusterclasses/charts/outscale/templates/ClusterClass.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/templates/ClusterClass.yaml
@@ -13,12 +13,14 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OscClusterTemplate
       name: {{ include "outscale.name" . }}
+      namespace: default
 
   controlPlane:
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
       name: {{ include "outscale.name" $ }}
+      namespace: default
     namingStrategy:
       template: {{`"{{ .cluster.name }}-{{ .random }}"`}}
     machineInfrastructure:
@@ -26,19 +28,11 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OscMachineTemplate
         name: {{ include "outscale.name" $ }}-controlplane
+        namespace: default
+    {{- with $.Values.machineHealthCheck }}
     machineHealthCheck:
-      maxUnhealthy: 100%
-      nodeStartupTimeout: 20m0s
-      unhealthyConditions:
-        - type: Ready
-          status: Unknown
-          timeout: 5m0s
-        - type: Ready
-          status: "False"
-          timeout: 20m0s
-        - status: "True"
-          timeout: 1m0s
-          type: DiskPressure
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
 
   workers:
     machineDeployments:
@@ -57,30 +51,24 @@ spec:
               apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
               kind: KubeadmConfigTemplate
               name: {{ include "outscale.name" $ }}
+              namespace: default
           infrastructure:
             ref:
               apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
               kind: OscMachineTemplate
               name: {{ include "outscale.name" $ }}-worker-{{ $name }}
+              namespace: default
           metadata: {}
+        {{- with $.Values.machineHealthCheck }}
         machineHealthCheck:
-          maxUnhealthy: 100%
-          nodeStartupTimeout: 20m0s
-          unhealthyConditions:
-            - type: Ready
-              status: Unknown
-              timeout: 5m0s
-            - type: Ready
-              status: "False"
-              timeout: 20m0s
-            - status: "True"
-              timeout: 1m0s
-              type: DiskPressure
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
       {{- end }}
 
   variables:
     - name: bastion
       required: false
+      metadata: {}
       schema:
         openAPIV3Schema:
           type: object
@@ -93,17 +81,14 @@ spec:
             vmSize:
               type: string
               description: size of the bastion VM. This must be a valid Outscale vmType
-              default: tinav5.c4r8p3
               example: tinav5.c4r8p3
             imageName:
               type: string
               description: name of the image to use to provision the bastion VM
-              default: ubuntu-2204-2204-kubernetes-v1.28.5-2024-01-10
               example: ubuntu-2204-2204-kubernetes-v1.28.5-2024-01-10
             subregionName:
               type: string
               description: name of the subregion where the bastion will be deployed
-              default: eu-west-2a
               example: eu-west-2a, eu-west-2b
             rootDisk:
               type: object
@@ -121,27 +106,23 @@ spec:
                   description: type of the root disk
                   default: standard
                   enum: ["standard", "gp2", "io1"]
-              default:
-                iops: 1000
-                size: 50
-                type: standard
             allow_cidr:
               type: array
               items:
                 type: string
               description: list of CIDRs that are allowed to connect to the bastion
-              default: []
-          required: []
           default:
             enable: false
     - name: sshKeypairName
       required: true
+      metadata: {}
       schema:
         openAPIV3Schema:
           type: string
           description: name of the SSH Keypair to inject into all the VMs of the cluster
     - name: subregionName
       required: false
+      metadata: {}
       schema:
         openAPIV3Schema:
           type: string
@@ -149,7 +130,6 @@ spec:
             Name of the Outscale subregion to use to deploy resources that
             do require subregion to be documented (bastion, subnets,
             OscMachineTemplates dedicated one specific AZ)
-          default: eu-west-2a
           example: eu-west-2a, eu-west-2b
     - name: coreDNSVersion
       # coredns is not upgraded automaticaly by cluster api
@@ -158,18 +138,21 @@ spec:
       # and for default version for each kubernets versions:
       # https://github.com/kubernetes/kubernetes/blob/v1.28.5/cmd/kubeadm/app/constants/constants.go#L344
       required: true
+      metadata: {}
       schema:
         openAPIV3Schema:
           type: string
           description: coredns image version (corends is not upgraded automaticaly by cluster api)
     - name: vmImageName
       required: true
+      metadata: {}
       schema:
         openAPIV3Schema:
           type: string
           description: name of the image to use to provision controlplane and worker VMs
     - name: controlPlane
       required: true
+      metadata: {}
       schema:
         openAPIV3Schema:
           type: object
@@ -202,6 +185,7 @@ spec:
             - vmSize
     - name: workers
       required: true
+      metadata: {}
       schema:
         openAPIV3Schema:
           type: object
@@ -574,6 +558,7 @@ spec:
                       {{`{{- end }}`}}
 
     # OscClusterTemplate patches for the bastion
+    # patches bastion properties if enable
     - name: oct_bastion
       enabledIf: {{`"{{ .bastion.enable }}"`}}
       definitions:
@@ -602,7 +587,7 @@ spec:
                   subregionName: {{ .bastion.subregionName }}
                   securityGroupNames:
                     - name: {{ printf "%s-securitygroup-bastion" .builtin.cluster.name }}
-                  publicIpNameAfterBastion: true`}}
+                  publicIpName: {{ printf "%s-publicip-bastion" .builtin.cluster.name }}`}}
             - op: add
               path: /spec/template/spec/network/publicIps/-
               valueFrom:
@@ -635,4 +620,4 @@ spec:
                       ipProtocol: tcp
                       ipRange: {{ $cidr }}
                     {{- end }}`}}
-                  
+

--- a/helm-charts/capi-clusterclasses/charts/outscale/templates/ClusterClass.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/templates/ClusterClass.yaml
@@ -132,17 +132,15 @@ spec:
             OscMachineTemplates dedicated one specific AZ)
           example: eu-west-2a, eu-west-2b
     - name: coreDNSVersion
-      # coredns is not upgraded automaticaly by cluster api
-      # We need to specify the target version for each cluster/clusterclass
-      # see https://github.com/kubernetes-sigs/cluster-api/issues/6429
-      # and for default version for each kubernets versions:
-      # https://github.com/kubernetes/kubernetes/blob/v1.28.5/cmd/kubeadm/app/constants/constants.go#L344
-      required: true
+      # The Coredns version is aligned with the Kubernetes version (via OS image-builder)
+      # You can override the version if necessary.
+      # see https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md
+      required: false
       metadata: {}
       schema:
         openAPIV3Schema:
           type: string
-          description: coredns image version (corends is not upgraded automaticaly by cluster api)
+          description: coredns image version
     - name: vmImageName
       required: true
       metadata: {}
@@ -220,6 +218,7 @@ spec:
   patches:
     # KubeadmControlPlaneTemplate patches
     - name: kcpt_main
+      enabledIf: {{ `"{{ if .coreDNSVersion }}true{{end}}"` }}
       definitions:
         - selector:
             apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -227,10 +226,10 @@ spec:
             matchResources:
               controlPlane: true
           jsonPatches:
-            - op: replace
+            - op: add
               path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns/imageTag
               valueFrom:
-                template: {{`"{{ .coreDNSVersion }}"`}}
+                variable: coreDNSVersion
 
     # OscMachineTemplate (ControlPlane) patches
     - name: omt_controlplane_main
@@ -558,7 +557,6 @@ spec:
                       {{`{{- end }}`}}
 
     # OscClusterTemplate patches for the bastion
-    # patches bastion properties if enable
     - name: oct_bastion
       enabledIf: {{`"{{ .bastion.enable }}"`}}
       definitions:

--- a/helm-charts/capi-clusterclasses/charts/outscale/templates/KubeadmControlPlaneTemplate.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/templates/KubeadmControlPlaneTemplate.yaml
@@ -40,8 +40,7 @@ spec:
           controllerManager:
             extraArgs:
               cloud-provider: "external"
-          dns:
-            imageTag: "0.0.0"   # will be patched by a ClusterClass patch
+          dns: {}   # will be patched by a ClusterClass patch
         initConfiguration:
           localAPIEndpoint:
             advertiseAddress: "0.0.0.0"

--- a/helm-charts/capi-clusterclasses/charts/outscale/templates/OscClusterTemplate.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/templates/OscClusterTemplate.yaml
@@ -11,8 +11,7 @@ spec:
     spec:
       network:
         clusterName: "must-be-patched"
-        bastion:        # will be patched by a ClusterClass patch
-          enable: false
+        bastion: {}     # will be patched by a ClusterClass patch
         internetService:
           clusterName: "must-be-patched"
         publicIps:      # will be patched by a ClusterClass patch

--- a/helm-charts/capi-clusterclasses/charts/outscale/templates/OscMachineTemplate-control-plane.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/templates/OscMachineTemplate-control-plane.yaml
@@ -20,7 +20,7 @@ spec:
           keypairName: "must-be-patched"
           loadBalancerName: "must-be-patched"
           role: controlplane
-          vmType: "tinav5.c2r4p3"   # will be patched by ClusterClass
+          vmType: {{ .Values.controlplane.vmType | default "tinav5.c2r4p3"  }}
           # securityGroupNames: []
           {{- if hasKey .Values.controlplane "rootDisk" }}
           rootDisk:

--- a/helm-charts/capi-clusterclasses/charts/outscale/templates/OscMachineTemplate-worker.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/templates/OscMachineTemplate-worker.yaml
@@ -20,7 +20,7 @@ spec:
         vm:
           clusterName: "must-be-patched"
           keypairName: "must-be-patched"
-          vmType: "tinav5.c2r4p3"   # will be patched by ClusterClass
+          vmType: {{ $mt.vmType | default "tinav5.c2r4p3"  }}
           # securityGroupNames: []
           {{- if hasKey $mt "subregionName" }}
           subregionName: {{ $mt.subregionName  }}

--- a/helm-charts/capi-clusterclasses/charts/outscale/values.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/values.yaml
@@ -16,6 +16,7 @@ machineHealthCheck:
 
 # # properties of the controlplane
 # controlplane:
+#   vmType: tinav5.c2r4p3
 #   rootDisk:
 #     rootDiskIops: 1000
 #     rootDiskSize: 50
@@ -28,6 +29,7 @@ machineHealthCheck:
   
 #   # for workers that will *not* be hosted in a specific availability zone
 #   md-regionwide-class:
+#     vmType: tinav5.c2r4p3
 #     rootDisk:
 #       rootDiskIops: 100
 #       rootDiskSize: 30

--- a/helm-charts/capi-clusterclasses/charts/outscale/values.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/values.yaml
@@ -1,5 +1,18 @@
 # # Default values for capi-clusterclasses.
 # # This is a YAML-formatted file.
+machineHealthCheck:
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 20m0s
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 5m0s
+    - type: Ready
+      status: "False"
+      timeout: 20m0s
+    - status: "True"
+      timeout: 1m0s
+      type: DiskPressure
 
 # # properties of the controlplane
 # controlplane:

--- a/helm-charts/capi-clusterclasses/values.yaml
+++ b/helm-charts/capi-clusterclasses/values.yaml
@@ -7,40 +7,58 @@ provider:
   outscale: false
 
 # values that are specific to the provider 'outscale'
-outscale:
-  # properties of the controlplane
-  controlplane:
-    rootDisk:
-      rootDiskIops: 1000
-      rootDiskSize: 50
-      rootDiskType: gp2
+outscale: {}
 
-  # properties of the workers
-  workers:
-    # the names of these dictionaries will be used in the template 'ClusterClass.yaml'
-    # as the names of the 'MachineDeployment classes'
-    
-    # for workers that will *not* be hosted in a specific availability zone
-    md-regionwide-class:
-      rootDisk:
-        rootDiskIops: 100
-        rootDiskSize: 30
-        rootDiskType: standard
-
-    # for workers that will be hosted in a specific availability zone
-    # note that the name 'az1' is irrelevent, it could be anything
-    md-az1-class:
-      subregionName: eu-west-2a
-      rootDisk:
-        rootDiskIops: 100
-        rootDiskSize: 30
-        rootDiskType: standard
-
-    # for workers that will be hosted in a specific availability zone
-    # note that the name 'az2' is irrelevent, it could be anything
-    md-az2-class:
-      subregionName: eu-west-2b
-      rootDisk:
-        rootDiskIops: 100
-        rootDiskSize: 30
-        rootDiskType: standard
+## sample value below
+#outscale:
+#  # properties of machineHealthCheck
+#  machineHealthCheck:
+#    maxUnhealthy: 100%
+#    nodeStartupTimeout: 20m0s
+#    unhealthyConditions:
+#      - type: Ready
+#        status: Unknown
+#        timeout: 5m0s
+#      - type: Ready
+#        status: "False"
+#        timeout: 20m0s
+#      - status: "True"
+#        timeout: 1m0s
+#        type: DiskPressure
+#
+#  # properties of the controlplane
+#  controlplane:
+#    rootDisk:
+#      rootDiskIops: 1000
+#      rootDiskSize: 50
+#      rootDiskType: gp2
+#
+#  # properties of the workers
+#  workers:
+#    # the names of these dictionaries will be used in the template 'ClusterClass.yaml'
+#    # as the names of the 'MachineDeployment classes'
+#
+#    # for workers that will *not* be hosted in a specific availability zone
+#    md-regionwide-class:
+#      rootDisk:
+#        rootDiskIops: 100
+#        rootDiskSize: 30
+#        rootDiskType: standard
+#
+#    # for workers that will be hosted in a specific availability zone
+#    # note that the name 'az1' is irrelevent, it could be anything
+#    md-az1-class:
+#      subregionName: eu-west-2a
+#      rootDisk:
+#        rootDiskIops: 100
+#        rootDiskSize: 30
+#        rootDiskType: standard
+#
+#    # for workers that will be hosted in a specific availability zone
+#    # note that the name 'az2' is irrelevent, it could be anything
+#    md-az2-class:
+#      subregionName: eu-west-2b
+#      rootDisk:
+#        rootDiskIops: 100
+#        rootDiskSize: 30
+#        rootDiskType: standard

--- a/helm-charts/capi-clusterclasses/values.yaml
+++ b/helm-charts/capi-clusterclasses/values.yaml
@@ -28,6 +28,7 @@ outscale: {}
 #
 #  # properties of the controlplane
 #  controlplane:
+#    vmType: tinav5.c2r4p3
 #    rootDisk:
 #      rootDiskIops: 1000
 #      rootDiskSize: 50
@@ -40,6 +41,7 @@ outscale: {}
 #
 #    # for workers that will *not* be hosted in a specific availability zone
 #    md-regionwide-class:
+#     vmType: tinav5.c2r4p3
 #      rootDisk:
 #        rootDiskIops: 100
 #        rootDiskSize: 30

--- a/helm-charts/samples/capi-clusterclasses.yaml.sample
+++ b/helm-charts/samples/capi-clusterclasses.yaml.sample
@@ -1,0 +1,48 @@
+# Default values for capi-clusterclasses.
+# This is a YAML-formatted file.
+
+# this is used in the helm chart to decide which subchart to enable
+# see dependencies[].condition in Chart.yaml
+provider:
+  outscale: true
+
+# values that are specific to the provider 'outscale'
+#outscale: {}
+## sample value below
+outscale:
+  # properties of the controlplane
+  controlplane:
+    rootDisk:
+      rootDiskIops: 1000
+      rootDiskSize: 50
+      rootDiskType: gp2
+
+  # properties of the workers
+  workers:
+    # the names of these dictionaries will be used in the template 'ClusterClass.yaml'
+    # as the names of the 'MachineDeployment classes'
+
+    # for workers that will *not* be hosted in a specific availability zone
+    md-regionwide-class:
+      rootDisk:
+        rootDiskIops: 100
+        rootDiskSize: 30
+        rootDiskType: standard
+
+    # for workers that will be hosted in a specific availability zone
+    # note that the name 'az1' is irrelevent, it could be anything
+    md-az1-class:
+      subregionName: eu-west-2a
+      rootDisk:
+        rootDiskIops: 100
+        rootDiskSize: 30
+        rootDiskType: standard
+
+    # for workers that will be hosted in a specific availability zone
+    # note that the name 'az2' is irrelevent, it could be anything
+    md-az2-class:
+      subregionName: eu-west-2b
+      rootDisk:
+        rootDiskIops: 100
+        rootDiskSize: 30
+        rootDiskType: standard


### PR DESCRIPTION
This PR fix the following:

- fix sync differences in argo

in helm-charts/capi-clusterclasses:
- the global values ​​file must be empty, to be adapted and overridden at deployment time.
- unset bastion default values in variables key.  bastion is disabled by default. Thoses values must be defined at deployment time.
- namespace key must be defined
- empty metadata key must be defined in variables objects
- machinehealthcheck values are now defined in values file


- add ci/test makefile and sample test file

Tested successfully with kubernetes version:
- [x] v1.28.5
- [x] v1.30.11
- [x] v1.31.7
- [x] v1.32.3