### PR TITLE
features: OscMachineTemplate name with sha256

### DIFF
--- a/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
@@ -370,7 +370,9 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OscMachineTemplate
-      name: {{ .Values.global.clusterName }}-control-plane-{{ .Values.controlplane.version }}
+      name: {{- $base := printf "%s-%s-%s" .Values.global.clusterName "control-plane" .Values.controlplane.version -}}
+            {{- $hash := sha256sum .Values.controlplane.image | trunc 8 -}}
+            {{- printf "%s-%s" $base $hash | trunc 63 | indent 1 }}
   replicas: {{ .Values.controlplane.replicas | default 1 }}
   version: {{ .Values.controlplane.version }}
   rolloutStrategy:

--- a/helm-charts/capi-cluster/charts/outscale/templates/MachineDeployment.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/MachineDeployment.yaml
@@ -31,7 +31,10 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OscMachineTemplate
-        name: {{ $.Values.global.clusterName }}-{{ $name }}-{{ $pool.version }}{{ if $.Values.multiaz }}-{{ . }}{{ end }}
+        name: {{- $base := printf "%s-%s-%s" $.Values.global.clusterName $name $pool.version -}}
+              {{- if $.Values.multiaz }}{{- $base = printf "%s-%s" $base . }}{{- end -}}
+              {{- $hash := sha256sum $pool.image | trunc 8 -}}
+              {{- printf "%s-%s" $base $hash | trunc 63 | indent 1 }}
       version: {{ $pool.version }}
 {{- end }}
 {{- end }}

--- a/helm-charts/capi-cluster/charts/outscale/templates/OscMachineTemplate-control-plane.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/OscMachineTemplate-control-plane.yaml
@@ -1,7 +1,9 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OscMachineTemplate
 metadata:
-  name: {{ .Values.global.clusterName }}-control-plane-{{ .Values.controlplane.version }}
+  name: {{- $base := printf "%s-%s-%s" .Values.global.clusterName "control-plane" .Values.controlplane.version -}}
+        {{- $hash := sha256sum .Values.controlplane.image | trunc 8 -}}
+        {{- printf "%s-%s" $base $hash | trunc 63 | indent 1 }}
 spec:
   template:
     spec:

--- a/helm-charts/capi-cluster/charts/outscale/templates/OscMachineTemplate-md.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/OscMachineTemplate-md.yaml
@@ -6,7 +6,9 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OscMachineTemplate
 metadata:
-  name: {{ $.Values.global.clusterName }}-{{ $name }}-{{ $pool.version }}-{{ . }}
+  name: {{- $base := printf "%s-%s-%s-%s" $.Values.global.clusterName $name $pool.version . -}}
+        {{- $hash := sha256sum $pool.image | trunc 8 -}}
+        {{- printf "%s-%s" $base $hash | trunc 63 | indent 1 }}
 spec:
   template:
     spec:
@@ -46,7 +48,9 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OscMachineTemplate
 metadata:
-  name: {{ $.Values.global.clusterName }}-{{ $name }}-{{ $pool.version }}
+  name: {{- $base := printf "%s-%s-%s" $.Values.global.clusterName $name $pool.version -}}
+        {{- $hash := sha256sum $pool.image | trunc 8 -}}
+        {{- printf "%s-%s" $base $hash | trunc 63 | nindent 4 }}
 spec:
   template:
     spec:

--- a/helm-charts/samples/c2-demo.yaml.sample
+++ b/helm-charts/samples/c2-demo.yaml.sample
@@ -47,7 +47,7 @@ global:
 
 outscale:
   sshkeyname: REPLACE_SSH_KEY_NAME_
-  subregionname: eu-west-2a
+  subregionName: eu-west-2a
   osc_ccm_credentials:
     secret_key: ""
     access_key: ""
@@ -71,7 +71,7 @@ outscale:
   controlplane:
     version: v1.30.5
     replicas: 1
-    image: ubuntu-2204-2204-kubernetes-v1.30.5-2024-10-21
+    image: ubuntu-2204-2204-kubernetes-v1.30.5-2024-10-22
     vmType: tinav5.c4r8p2
     subregionName: eu-west-2a
     rootDisk:


### PR DESCRIPTION
This PR defines the name of the OscMachineTemplate object based on a sha256.

Indeed, OscMachineTemplate objects are immutable. The name must be different to trigger a node replacement.

This allows cluster upgrades to be performed automatically based on changes to Kubernetes versions and also on image version names.