### PR TITLE
feat(openstack): add apiServerVirtualIP for controlplanes

### DIFF
--- a/helm-charts/capi-cluster/charts/openstack/templates/KubeadmControlPlane.yaml
+++ b/helm-charts/capi-cluster/charts/openstack/templates/KubeadmControlPlane.yaml
@@ -167,7 +167,8 @@ spec:
               - name: vip_retryperiod
                 value: "2"
               - name: address
-                value: {{ .Values.controlplane.apiServerFixedIP }}
+                value: {{ .Values.controlplane.apiServerVirtualIP | default .Values.controlplane.apiServerFixedIP }}
+
               - name: prometheus_server
                 value: :2112
               image: ghcr.io/kube-vip/kube-vip:{{ .Values.global.addons.kubevip.version }}

--- a/helm-charts/capi-cluster/charts/openstack/templates/OpenStackMachineTemplate-control-plane.yaml
+++ b/helm-charts/capi-cluster/charts/openstack/templates/OpenStackMachineTemplate-control-plane.yaml
@@ -36,7 +36,7 @@ spec:
 #            - filter:
 #                name: allow-ssh
           allowedAddressPairs:
-            - ipAddress: {{ .Values.controlplane.apiServerFixedIP }}
+            - ipAddress: {{ .Values.controlplane.apiServerVirtualIP | default .Values.controlplane.apiServerFixedIP }}
 #          disablePortSecurity: true
 #
       {{- if .Values.controlplane.rootVolume }}

--- a/helm-charts/capi-cluster/charts/openstack/values.yaml
+++ b/helm-charts/capi-cluster/charts/openstack/values.yaml
@@ -25,6 +25,7 @@ addons:
 #  image: ubuntu-2204-kube-v1.29.4
 #  flavor: CO1.2
 #  apiServerFixedIP: 192.168.101.10
+#  apiServerVirtualIP: 192.168.200.10
 #  availabilityZones:
 #    - AZ1
 #    - AZ2

--- a/helm-charts/capi-cluster/values.yaml
+++ b/helm-charts/capi-cluster/values.yaml
@@ -256,6 +256,8 @@ openstack: {}
 #      - AZ2
 #    # reserved ip/port outside cluster-api
 #    apiServerFixedIP: 192.168.101.10
+#    # if controlplane VirtualIP is different from apiServerFixedIP
+#    apiServerVirtualIP: 192.168.200.10
 #    #rootVolume: {}
 #  workers:
 #    md-0:


### PR DESCRIPTION
This PR add 

On openstack capi_cluster helm chart,  optionnal new variable:

- apiServerVirtualIP: which is the private Virtual IP set on all control plane  (with kube-vip)
apiServerVirtualIP must be associated with a apiServerFixedIP  (a FloatingIP) , which is the IP used by kubeadm

If not set, the default behaviour is tu use the apiServerFixedIP for virtual ip and api endpoint


