### PR TITLE
patch(coredns): anti-affinity

### DIFF
--- a/helm-charts/capi-cluster/charts/openstack/templates/KubeadmControlPlane.yaml
+++ b/helm-charts/capi-cluster/charts/openstack/templates/KubeadmControlPlane.yaml
@@ -112,6 +112,39 @@ spec:
           {{- tpl (. | toYaml) $ | nindent 10 }}
           {{- end }}
 
+      - path: /etc/kubernetes/patches/coredns-anti-affinity.yaml
+        owner: root:root
+        permissions: "0644"
+        content: |
+          spec:
+            template:
+              spec:
+                affinity:
+                  podAntiAffinity:
+                    $patch: replace
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                    - topologyKey: kubernetes.io/hostname
+                      labelSelector:
+                        matchExpressions:
+                        - key: k8s-app
+                          operator: In
+                          values:
+                          - kube-dns
+
+      - path: /etc/post-kubeadm-commands/20-coredns-anti-affinity.sh
+        owner: root:root
+        permissions: "0755"
+        content: |
+          #!/bin/bash
+          set -euo pipefail
+
+          /usr/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf \
+            -n kube-system wait deploy/coredns --for=condition=available --timeout=5m
+
+          /usr/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf \
+            -n kube-system patch deploy coredns --type=strategic \
+            --patch-file /etc/kubernetes/patches/coredns-anti-affinity.yaml
+
       - path: /etc/pre-kubeadm-commands/10-containerd-restart.sh
         owner: root:root
         permissions: "0700"

--- a/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/KubeadmControlPlane.yaml
@@ -129,6 +129,39 @@ spec:
           {{- tpl (. | toYaml) $ | nindent 10 }}
           {{- end }}
 
+      - path: /etc/kubernetes/patches/coredns-anti-affinity.yaml
+        owner: root:root
+        permissions: "0644"
+        content: |
+          spec:
+            template:
+              spec:
+                affinity:
+                  podAntiAffinity:
+                    $patch: replace
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                    - topologyKey: kubernetes.io/hostname
+                      labelSelector:
+                        matchExpressions:
+                        - key: k8s-app
+                          operator: In
+                          values:
+                          - kube-dns
+
+      - path: /etc/post-kubeadm-commands/20-coredns-anti-affinity.sh
+        owner: root:root
+        permissions: "0755"
+        content: |
+          #!/bin/bash
+          set -euo pipefail
+
+          /usr/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf \
+            -n kube-system wait deploy/coredns --for=condition=available --timeout=5m
+
+          /usr/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf \
+            -n kube-system patch deploy coredns --type=strategic \
+            --patch-file /etc/kubernetes/patches/coredns-anti-affinity.yaml
+
       - path: /etc/pre-kubeadm-commands/00-wait_endpoint.sh
         owner: root:root
         permissions: "0755"

--- a/helm-charts/capi-clusterclasses/charts/outscale/templates/ClusterClass.yaml
+++ b/helm-charts/capi-clusterclasses/charts/outscale/templates/ClusterClass.yaml
@@ -744,4 +744,3 @@ spec:
                       ipProtocol: tcp
                       ipRange: {{ $cidr }}
                     {{- end }}`}}
-


### PR DESCRIPTION
Patch core Dns affinity to use requiredDuringSchedulingIgnoredDuringExecution: instead of prefered... : 

Use case: Force the pods to run on different nodes

rollout cp to apply : 

NB: cette commande doit être exécutée sur le cluster de management
kubectl patch kcp <cluster-name>-control-plane --type merge -p "{\"spec\": {\"rolloutAfter\": \"$(date --utc +"%Y-%m-%dT%H:%M:%SZ")\"}}" 

result: 
```yaml  
  template:
    metadata:
      creationTimestamp: null
      labels:
        k8s-app: kube-dns
    spec:
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: k8s-app
                operator: In
                values:
                - kube-dns
            topologyKey: kubernetes.io/hostname
      containers:
```