### PR TITLE
Allow (almost) any CIDR for VPC

### DIFF
--- a/helm-charts/capi-cluster/charts/outscale/templates/OscCluster.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/templates/OscCluster.yaml
@@ -21,6 +21,19 @@
   {{- $controlplane_ranges = append $controlplane_ranges (printf "10.%s.7.0/24" (toString .Values.networkId)) -}}
   {{- $controlplane_ranges = append $controlplane_ranges (printf "10.%s.10.0/24" (toString .Values.networkId)) -}}
 {{- end }}
+
+{{- if not .Values.useDeprecatedNetworkId }}
+  {{- $subnets := include "helm.subnet-list" .Values.vpc_cidr | fromJsonArray -}}
+    {{- if .Values.multiaz }}
+      {{- $controlplane_ranges = slice $subnets 0 3 -}}
+      {{- $worker_ranges = slice $subnets 3 6 -}}
+      {{- $loadbalancer_ranges = slice $subnets 6 9 -}}
+    {{- else }}
+      {{- $controlplane_ranges = index $subnets 0 -}}
+      {{- $worker_ranges = index $subnets 1 -}}  
+      {{- $loadbalancer_ranges = index $subnets 2 -}}  
+    {{- end }}
+{{- end }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OscCluster
 metadata:

--- a/helm-charts/capi-cluster/charts/outscale/templates/_helpers.tpl
+++ b/helm-charts/capi-cluster/charts/outscale/templates/_helpers.tpl
@@ -2,6 +2,65 @@
 Define Loadbalancer name : outscale limitation is max length 32
  default: if no loadbalancername is specified, generate 32 max length loadbalancername from trunc(28, sha256(cluster name))"-k8s"
 */}}
+{{/*
+  helm.subnet-list
+  Returns a JSON array of 9 subnet CIDRs carved from a given network CIDR.
+
+  Usage:
+    {{ include "helm.subnet-list" "10.0.0.0/16" }}
+
+  Constraints:
+    - Base prefix must be between /16 and /24 (subnets will be /prefix+4)
+    - 9 × blockSize must fit within the parent network
+*/}}
+{{- define "helm.subnet-list" -}}
+  {{- $parts  := splitList "/" . -}}
+  {{- $ip     := index $parts 0 -}}
+  {{- $prefix := index $parts 1 | int -}}
+
+  {{- $octets := splitList "." $ip -}}
+  {{- $o1     := index $octets 0 | int -}}
+  {{- $o2     := index $octets 1 | int -}}
+  {{- $o3     := index $octets 2 | int -}}
+  {{- $o4     := index $octets 3 | int -}}
+
+  {{- $subPrefix := add $prefix 4 -}}
+
+  {{/* Block sizes keyed by subnet prefix: 2^(32-subPrefix) */}}
+  {{- $blockSizes := dict
+      "16" 65536
+      "17" 32768
+      "18" 16384
+      "19" 8192
+      "20" 4096
+      "21" 2048
+      "22" 1024
+      "23" 512
+      "24" 256
+      "25" 128
+      "26" 64
+      "27" 32
+      "28" 16
+  -}}
+
+  {{- $blockSize := index $blockSizes (toString $subPrefix) -}}
+  {{- if not $blockSize -}}
+    {{- fail (printf "helm.subnet-list: unsupported prefix /%d (subnet prefix /%d). Base prefix must be between /16 and /24." $prefix $subPrefix) -}}
+  {{- end -}}
+  {{- $blockSize = int $blockSize -}}
+
+  {{- $subnets := list -}}
+  {{- range $i := until 9 -}}
+    {{- $offset := mul $blockSize $i -}}
+    {{- $newO2  := add $o2 (mod (div $offset 65536) 256) -}}
+    {{- $newO3  := add $o3 (mod (div $offset 256) 256) -}}
+    {{- $newO4  := add $o4 (mod $offset 256) -}}
+    {{- $subnet := printf "%d.%d.%d.%d/%d" $o1 $newO2 $newO3 $newO4 $subPrefix -}}
+    {{- $subnets = append $subnets $subnet -}}
+  {{- end -}}
+
+  {{- toJson $subnets -}}
+{{- end -}}
 
 {{- define "outscale.defaultLoadbalancerName" -}}
 {{- $loadbalancername := printf "%s-%s" (lower .Values.global.clusterName | sha256sum | trunc 28 ) "k8s" }}

--- a/helm-charts/capi-cluster/charts/outscale/values.yaml
+++ b/helm-charts/capi-cluster/charts/outscale/values.yaml
@@ -12,13 +12,17 @@ addons:
 certmanager: {}
 csi: {}
 
-# Allow to change default network CIDR.
+# Deprecated (use vpc_cidr): Allow to change default network CIDR.
 # There is a lot of logic behind so for now you can only change
 # the default 10.0.0.0/16 network by changing the second bit. For
 # example setting `networkId: 123` would create network and routes
 # for CIDR 10.123.0.0/16.
 # WARNING: Please remember "10.96.0.0/12" and "10.42.0.0/16" are reserved by default.
 networkId: 0
+useDeprecatedNetworkId: false
+
+# CIDR for the VPC, subnets will be automatically calculated
+vpc_cidr: 10.0.0.0/16
 
 #dockerConfig:
 #  registry: https://index.docker.io/v1/


### PR DESCRIPTION
New value `vpc_cidr` allows to choose any CIDR between /24 and /16 and will automatically calculate CIDR for subnets.
To avoid breaking change, and to keep old way of CIDR calculation it is possible to use `useDeprecatedNetworkId` value. Otherwise, if set to false (default) networkId will be ignored.